### PR TITLE
Update test apps

### DIFF
--- a/expo-52-prebuild-with-plugins/app/(tabs)/plugins.tsx
+++ b/expo-52-prebuild-with-plugins/app/(tabs)/plugins.tsx
@@ -31,6 +31,7 @@ const rootReducer = (state = initialState, action) => {
 
 const store = configureStore({
   reducer: rootReducer,
+  // Comment two lines below and reload to test our first-party redux support otherwise you're testing expo dev plugins 
   devTools: false,
   enhancers: (getDefaultEnhancers) =>
     getDefaultEnhancers().concat(devToolsEnhancer()),

--- a/shared/src/MainScreen.tsx
+++ b/shared/src/MainScreen.tsx
@@ -64,6 +64,15 @@ export function MainScreen() {
             Click a button to throw an exception and verify IDE catches that
             with "Uncaught exception" overlay.
           </Step>
+          <Step
+            label="Fetch request visible in network panel"
+            onPress={async () => {
+              const response = await fetch("https://pokeapi.co/api/v2/pokemon/ditto");
+              console.log('Response', response);
+            }}
+          >
+            Activate network panel, click button and see if fetch request is visible
+          </Step>
           <Step label="Inspector button (left and right click)">
             Click inspector button, hover over components and jump to the
             component after click. Right click the selected component and verify


### PR DESCRIPTION
Adds comment about changing redux configuration + button to testing network panel 

Test:
- run `npm run copy-shared` and use fetch button to test network inspector 