### PR TITLE
Fix expo router for automated tests

### DIFF
--- a/shared/src/ExpoRouter.tsx
+++ b/shared/src/ExpoRouter.tsx
@@ -1,0 +1,6 @@
+let router: any = null;
+try {
+  router = require('expo-router').router;
+} catch {}
+
+export default router;

--- a/shared/src/automatedTests.tsx
+++ b/shared/src/automatedTests.tsx
@@ -11,22 +11,7 @@ import { Appearance, useColorScheme, AppState } from "react-native";
 import { Dimensions } from "react-native";
 import { PixelRatio } from "react-native";
 import { getWebSocket } from "./websocket";
-
-let useRouter: (() => { push: (path: string) => void }) | null = null;
-
-try {
-  useRouter = require("expo-router").useRouter;
-} catch (e) {
-  useRouter = null;
-}
-
-preview(
-  <TrackableButton
-    id="preview-button"
-    title="Preview Button"
-    onPress={printLogs}
-  />
-);
+import router from "./ExpoRouter";
 
 async function printLogs() {
   // put breakpoint on the next line
@@ -55,7 +40,6 @@ export function AutomatedTests() {
   const style = useStyle();
   const [elementVisible, setElementVisible] = useState(true);
   const ws = getWebSocket();
-  const router = useRouter ? useRouter() : null;
 
   useEffect(() => {
     if (!ws) return;


### PR DESCRIPTION
Dynamic importing expo-router caused problems with other imported files when it wasn’t in a separate file.